### PR TITLE
Version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssz_types"
-version = "1.0.0-beta.0"
+version = "0.5.0"
 edition = "2021"
 description = "List, vector and bitfield types for SSZ"
 license = "Apache-2.0"
@@ -11,9 +11,9 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-tree_hash = "1.0.0-beta.0"
-ethereum_ssz = "1.0.0-beta.0"
-ethereum_serde_utils = "1.0.0-beta.0"
+tree_hash = "0.5.0"
+ethereum_ssz = "0.5.0"
+ethereum_serde_utils = "0.5.0"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"
@@ -23,4 +23,4 @@ arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"
-tree_hash_derive = "1.0.0-beta.0"
+tree_hash_derive = "0.5.0"


### PR DESCRIPTION
Aligning with other crates, we can't go 1.0 because of `ethereum-types` dependency.