### PR TITLE
Abstract quoted serde utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ typenum = "1.12.0"
 derivative = "2.1.1"
 smallvec = "1.8.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
+itertools = "0.10.0"
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -220,6 +220,28 @@ where
     }
 }
 
+impl<T, N: Unsigned> ssz::TryFromIter<T> for VariableList<T, N> {
+    type Error = Error;
+
+    fn try_from_iter<I>(value: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let n = N::to_usize();
+        let iter = value.into_iter();
+
+        // Pre-allocate up to `N` elements based on the iterator size hint.
+        let (_, opt_max_len) = iter.size_hint();
+        let mut l = Self::new(Vec::with_capacity(
+            opt_max_len.map_or(n, |max_len| std::cmp::min(n, max_len)),
+        ))?;
+        for item in iter {
+            l.push(item)?;
+        }
+        Ok(l)
+    }
+}
+
 impl<T, N> ssz::Decode for VariableList<T, N>
 where
     T: ssz::Decode,


### PR DESCRIPTION
This change unifies the `serde_utils` for u64 lists and vectors using the `ssz::TryFromIter` trait. This also makes the utils compatible with `milhouse` types which implement the same trait.

Care has been taken to avoid memory DoS attacks in the new implementations of `TryFromIter` for `VariableList` and `FixedVector`.

I need to think further about whether this is a semver breaking change.