### PR TITLE
Implement IntoIter for VariableList

### DIFF
--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -176,6 +176,15 @@ impl<'a, T, N: Unsigned> IntoIterator for &'a VariableList<T, N> {
     }
 }
 
+impl<T, N: Unsigned> IntoIterator for VariableList<T, N> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}
+
 impl<T, N: Unsigned> tree_hash::TreeHash for VariableList<T, N>
 where
     T: tree_hash::TreeHash,


### PR DESCRIPTION
This ports across @paulhauner's changes from https://github.com/sigp/lighthouse/pull/3983 which implement `IntoIter` for `VariableList.`