### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,3 +31,18 @@ jobs:
       run: rustup update stable
     - name: Run tests
       run: cargo test --release
+  coverage:
+    name: cargo-tarpaulin
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Install cargo-tarpaulin
+      uses: taiki-e/install-action@cargo-tarpaulin
+    - name: Check code coverage with cargo-tarpaulin
+      run: cargo-tarpaulin --workspace --all-features --out xml
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true


### PR DESCRIPTION
Resolves #16 

Adds code coverage using `cargo-tarpaulin` and uploads the results to codecov.io to generate a coverage report.