### PR TITLE
Update tree_hash to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-tree_hash = "0.5.0"
+tree_hash = "0.6.0"
 ethereum_ssz = "0.5.0"
 ethereum_serde_utils = "0.5.0"
 serde = "1.0.0"
@@ -24,4 +24,4 @@ itertools = "0.10.0"
 
 [dev-dependencies]
 serde_json = "1.0.0"
-tree_hash_derive = "0.5.0"
+tree_hash_derive = "0.6.0"


### PR DESCRIPTION
Update `tree_hash` to v0.6.0 to bring in the `ethereum_hashing` v0.6.0 dependency which improves SGX compat.