### PR TITLE
Added missing IntoIterator trait for FixedVector

### DIFF
--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -168,6 +168,15 @@ impl<'a, T, N: Unsigned> IntoIterator for &'a FixedVector<T, N> {
     }
 }
 
+impl<T, N: Unsigned> IntoIterator for FixedVector<T, N> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}
+
 impl<T, N: Unsigned> tree_hash::TreeHash for FixedVector<T, N>
 where
     T: tree_hash::TreeHash,


### PR DESCRIPTION
This makes calls to `into_iter()` work properly so we can replace all those:
```rust
    Vec::from(fixed_vec).into_iter()
```
with just:
```rust
    fixed_vec.into_iter()
```
we're gonna need a clippy rule to find them all...