### PR TITLE
chore: make the comment and impl of `len` consistent

### DIFF
--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -85,7 +85,7 @@ impl<T, N: Unsigned> FixedVector<T, N> {
     ///
     /// Exists for compatibility with `Vec`.
     pub fn len(&self) -> usize {
-        self.vec.len()
+        N::to_usize()
     }
 
     /// True if the type-level constant length of `self` is zero.


### PR DESCRIPTION
The comment says: 

> Identical to `self.capacity`, returns the type-level constant length.

This pr makes the comment and impl consistent.