### PR TITLE
chore(deps): change ethereum-types to alloy-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-tree_hash = "0.6.0"
-ethereum_ssz = "0.5.0"
-ethereum_serde_utils = "0.5.0"
+tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
+ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
+ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"
@@ -24,4 +24,4 @@ itertools = "0.10.0"
 
 [dev-dependencies]
 serde_json = "1.0.0"
-tree_hash_derive = "0.6.0"
+tree_hash_derive = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
-ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
+ethereum_serde_utils = "0.5"
+ethereum_ssz = "0.5"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"

--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -480,25 +480,25 @@ mod test {
         let fixed: FixedVector<A, U1> = FixedVector::from(vec![a]);
         assert_eq!(
             fixed.tree_hash_root(),
-            merkle_root(a.tree_hash_root().as_bytes(), 0)
+            merkle_root(a.tree_hash_root().as_slice(), 0)
         );
 
         let fixed: FixedVector<A, U8> = FixedVector::from(vec![a; 8]);
         assert_eq!(
             fixed.tree_hash_root(),
-            merkle_root(&repeat(a.tree_hash_root().as_bytes(), 8), 0)
+            merkle_root(&repeat(a.tree_hash_root().as_slice(), 8), 0)
         );
 
         let fixed: FixedVector<A, U13> = FixedVector::from(vec![a; 13]);
         assert_eq!(
             fixed.tree_hash_root(),
-            merkle_root(&repeat(a.tree_hash_root().as_bytes(), 13), 0)
+            merkle_root(&repeat(a.tree_hash_root().as_slice(), 13), 0)
         );
 
         let fixed: FixedVector<A, U16> = FixedVector::from(vec![a; 16]);
         assert_eq!(
             fixed.tree_hash_root(),
-            merkle_root(&repeat(a.tree_hash_root().as_bytes(), 16), 0)
+            merkle_root(&repeat(a.tree_hash_root().as_slice(), 16), 0)
         );
     }
 }

--- a/src/tree_hash.rs
+++ b/src/tree_hash.rs
@@ -29,7 +29,7 @@ where
 
             for item in vec {
                 hasher
-                    .write(item.tree_hash_root().as_bytes())
+                    .write(item.tree_hash_root().as_slice())
                     .expect("ssz_types vec should not contain more elements than max");
             }
 

--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -469,7 +469,7 @@ mod test {
             let fixed: VariableList<A, U1> = VariableList::from(vec![a; i]);
             assert_eq!(
                 fixed.tree_hash_root(),
-                padded_root_with_length(&repeat(a.tree_hash_root().as_bytes(), i), i, 1),
+                padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 1),
                 "U1 {}",
                 i
             );
@@ -479,7 +479,7 @@ mod test {
             let fixed: VariableList<A, U8> = VariableList::from(vec![a; i]);
             assert_eq!(
                 fixed.tree_hash_root(),
-                padded_root_with_length(&repeat(a.tree_hash_root().as_bytes(), i), i, 8),
+                padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 8),
                 "U8 {}",
                 i
             );
@@ -489,7 +489,7 @@ mod test {
             let fixed: VariableList<A, U13> = VariableList::from(vec![a; i]);
             assert_eq!(
                 fixed.tree_hash_root(),
-                padded_root_with_length(&repeat(a.tree_hash_root().as_bytes(), i), i, 13),
+                padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 13),
                 "U13 {}",
                 i
             );
@@ -499,7 +499,7 @@ mod test {
             let fixed: VariableList<A, U16> = VariableList::from(vec![a; i]);
             assert_eq!(
                 fixed.tree_hash_root(),
-                padded_root_with_length(&repeat(a.tree_hash_root().as_bytes(), i), i, 16),
+                padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 16),
                 "U16 {}",
                 i
             );


### PR DESCRIPTION
This is the 4th PR in the chain https://github.com/sigp/ethereum_ssz/pull/15 I think this is the last one? Not sure I am sleepy

Anyways ssz_types depends on the 3 other libraries so when there are releases for those we can update this PR instead of using the commits from my branches