### PR TITLE
Add Eq trait to FixedVector

### DIFF
--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -46,7 +46,7 @@ pub use typenum;
 /// assert_eq!(&long[..], &[1, 2, 3, 4, 0]);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
-#[derivative(PartialEq, Hash(bound = "T: std::hash::Hash"))]
+#[derivative(PartialEq, Eq, Hash(bound = "T: std::hash::Hash"))]
 #[serde(transparent)]
 pub struct FixedVector<T, N> {
     vec: Vec<T>,


### PR DESCRIPTION
The `FixedVector` implements `PartialEq` but not `Eq` trait and I don't see a reason why it wouldn't.