### PR TITLE
Increase the `smallvec` length for `Bitfield`

### DIFF
--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -12,9 +12,10 @@ use typenum::Unsigned;
 
 /// Maximum number of bytes to store on the stack in a bitfield's `SmallVec`.
 ///
-/// The default of 32 bytes is enough to take us through to ~500K validators, as the byte length of
-/// attestation bitfields is roughly `N // 32 slots // 64 committes // 8 bits`.
-pub const SMALLVEC_LEN: usize = 32;
+/// The default of 32 bytes is enough to take us through to ~1.31M validators,
+/// as the byte length of attestation bitfields is roughly `N // 32 slots // 64
+/// committes // 8 bits`.
+pub const SMALLVEC_LEN: usize = 80;
 
 /// A marker trait applied to `Variable` and `Fixed` that defines the behaviour of a `Bitfield`.
 pub trait BitfieldBehaviour: Clone {}

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -12,10 +12,10 @@ use typenum::Unsigned;
 
 /// Maximum number of bytes to store on the stack in a bitfield's `SmallVec`.
 ///
-/// The default of 32 bytes is enough to take us through to ~1.31M validators,
-/// as the byte length of attestation bitfields is roughly `N // 32 slots // 64
-/// committes // 8 bits`.
-pub const SMALLVEC_LEN: usize = 80;
+/// 128 bytes is enough to take us through to ~2M active validators, as the byte
+/// length of attestation bitfields is roughly `N // 32 slots // 64 committes //
+/// 8 bits`.
+pub const SMALLVEC_LEN: usize = 128;
 
 /// A marker trait applied to `Variable` and `Fixed` that defines the behaviour of a `Bitfield`.
 pub trait BitfieldBehaviour: Clone {}


### PR DESCRIPTION
Increases the size of the `Bitfield` on the stack to 80 bytes. If the `smallvec` exceeds this then it will allocate to the heap.

This has the effect of ensuring that the `Attestation` bitfield can live on the stack for all networks with up to ~1.31M validators.

Allocating the `Attestation` to the heap is slow and increase memory fragmentation. This affects attestation deserialisation (happens very frequently) and block deserialisation (happens less frequently, but is latency critical).
 
 ## Why 80 bytes?
 
 Let's look at byte sizes that are a multiple of 8 (64 bits, 1 word). We will assume that the number of validators supported by a given bitfield size is `N * 32 slots * 64 committees * 8 bits`.

- 64 bytes = 1,048,576 validators
- 72 bytes = 1,179,648 validators
- 80 bytes = 1,310,720 validators

At the time of writing, Ethereum has [1,071,080 active validators](https://beaconcha.in). 80 bytes seems to be a small enough number that gives us some headroom.

