### PR TITLE
Allow patch bumps for our SSZ crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography::cryptocurrencies"]
 [dependencies]
 tree_hash = "0.8.0"
 ethereum_serde_utils = "0.7.0"
-ethereum_ssz = "0.8.0"
+ethereum_ssz = "0.8"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"


### PR DESCRIPTION
Allows for `0.8.x` versions for `ethereum_ssz` and `ethereum_ssz_derive`.

This is driven by a new release on those crates: https://github.com/sigp/ethereum_ssz/releases/tag/v0.8.1