### PR TITLE
Release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssz_types"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "List, vector and bitfield types for SSZ"
 license = "Apache-2.0"


### PR DESCRIPTION
New minor release.

We need to do a minor version bump because we've changed the version of `ethereum_ssz` that we depend on from `0.7` to `0.8`.