### PR TITLE
Bump tree_hash version, allow SSZ patch updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography::cryptocurrencies"]
 [dependencies]
 tree_hash = "0.9"
 ethereum_serde_utils = "0.7.0"
-ethereum_ssz = "0.8.0"
+ethereum_ssz = "0.8"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-tree_hash = "0.8.0"
+tree_hash = "0.9"
 ethereum_serde_utils = "0.7.0"
 ethereum_ssz = "0.8.0"
 serde = "1.0.0"


### PR DESCRIPTION
Continuing the round-robin of version bumps