### PR TITLE
Update tree_hash crate version from 0.9 into 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-tree_hash = "0.9"
+tree_hash = "0.9.1"
 ethereum_serde_utils = "0.7.0"
 ethereum_ssz = "0.8"
 serde = "1.0.0"


### PR DESCRIPTION
https://github.com/Commit-Boost/commit-boost-client/issues/224

The ssz_types uses `tree_hash` crate and we've added `FixedBytes<const N: usize>` support for tree_hash@0.9.1.