### PR TITLE
Release v0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssz_types"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "List, vector and bitfield types for SSZ"
 license = "Apache-2.0"


### PR DESCRIPTION
New release for Pawan's fix:

- https://github.com/sigp/ssz_types/pull/43

Although this is a breaking change, it's also a bug fix, as the previous `Deserialize` implementation admitted invalid `VariableList`/`FixedVector`s. Nobody should have been relying on this behaviour.