### PR TITLE
Remove dangerous truncating `From` impls

### DIFF
--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -28,22 +28,21 @@ pub use typenum;
 /// ## Example
 ///
 /// ```
-/// use ssz_types::{FixedVector, typenum};
+/// use ssz_types::{Error, FixedVector, typenum};
 ///
 /// let base: Vec<u64> = vec![1, 2, 3, 4];
 ///
 /// // Create a `FixedVector` from a `Vec` that has the expected length.
-/// let exact: FixedVector<_, typenum::U4> = FixedVector::from(base.clone());
+/// let exact: FixedVector<_, typenum::U4> = FixedVector::try_from(base.clone()).unwrap();
 /// assert_eq!(&exact[..], &[1, 2, 3, 4]);
 ///
-/// // Create a `FixedVector` from a `Vec` that is too long and the `Vec` is truncated.
-/// let short: FixedVector<_, typenum::U3> = FixedVector::from(base.clone());
-/// assert_eq!(&short[..], &[1, 2, 3]);
+/// // Create a `FixedVector` from a `Vec` that is too long and you'll get an error.
+/// let err = FixedVector::<_, typenum::U3>::try_from(base.clone()).unwrap_err();
+/// assert_eq!(err, Error::OutOfBounds { i: 4, len: 3 });
 ///
-/// // Create a `FixedVector` from a `Vec` that is too short and the missing values are created
-/// // using `std::default::Default`.
-/// let long: FixedVector<_, typenum::U5> = FixedVector::from(base);
-/// assert_eq!(&long[..], &[1, 2, 3, 4, 0]);
+/// // Create a `FixedVector` from a `Vec` that is too short and you'll get an error.
+/// let err = FixedVector::<_, typenum::U5>::try_from(base.clone()).unwrap_err();
+/// assert_eq!(err, Error::OutOfBounds { i: 4, len: 5 });
 /// ```
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
@@ -111,14 +110,11 @@ impl<T, N: Unsigned> FixedVector<T, N> {
     }
 }
 
-impl<T: Default, N: Unsigned> From<Vec<T>> for FixedVector<T, N> {
-    fn from(mut vec: Vec<T>) -> Self {
-        vec.resize_with(Self::capacity(), Default::default);
+impl<T: Default, N: Unsigned> TryFrom<Vec<T>> for FixedVector<T, N> {
+    type Error = Error;
 
-        Self {
-            vec,
-            _phantom: PhantomData,
-        }
+    fn try_from(vec: Vec<T>) -> Result<Self, Error> {
+        Self::new(vec)
     }
 }
 
@@ -406,9 +402,10 @@ mod test {
 
     #[test]
     fn indexing() {
-        let vec = vec![1, 2];
+        let mut vec = vec![1, 2];
+        vec.resize_with(8192, u64::default);
 
-        let mut fixed: FixedVector<u64, U8192> = vec.clone().into();
+        let mut fixed: FixedVector<u64, U8192> = vec.clone().try_into().unwrap();
 
         assert_eq!(fixed[0], 1);
         assert_eq!(&fixed[0..1], &vec[0..1]);
@@ -419,25 +416,27 @@ mod test {
     }
 
     #[test]
-    fn length() {
+    fn wrong_length() {
+        // Too long.
         let vec = vec![42; 5];
-        let fixed: FixedVector<u64, U4> = FixedVector::from(vec.clone());
-        assert_eq!(&fixed[..], &vec[0..4]);
+        let err = FixedVector::<u64, U4>::try_from(vec.clone()).unwrap_err();
+        assert_eq!(err, Error::OutOfBounds { i: 5, len: 4 });
 
+        // Too short.
         let vec = vec![42; 3];
-        let fixed: FixedVector<u64, U4> = FixedVector::from(vec.clone());
-        assert_eq!(&fixed[0..3], &vec[..]);
-        assert_eq!(&fixed[..], &vec![42, 42, 42, 0][..]);
+        let err = FixedVector::<u64, U4>::try_from(vec.clone()).unwrap_err();
+        assert_eq!(err, Error::OutOfBounds { i: 3, len: 4 });
 
+        // Too short (empty).
         let vec = vec![];
-        let fixed: FixedVector<u64, U4> = FixedVector::from(vec);
-        assert_eq!(&fixed[..], &vec![0, 0, 0, 0][..]);
+        let err = FixedVector::<u64, U4>::try_from(vec).unwrap_err();
+        assert_eq!(err, Error::OutOfBounds { i: 0, len: 4 });
     }
 
     #[test]
     fn deref() {
         let vec = vec![0, 2, 4, 6];
-        let fixed: FixedVector<u64, U4> = FixedVector::from(vec);
+        let fixed: FixedVector<u64, U4> = FixedVector::try_from(vec).unwrap();
 
         assert_eq!(fixed.first(), Some(&0));
         assert_eq!(fixed.get(3), Some(&6));
@@ -447,7 +446,7 @@ mod test {
     #[test]
     fn iterator() {
         let vec = vec![0, 2, 4, 6];
-        let fixed: FixedVector<u64, U4> = FixedVector::from(vec);
+        let fixed: FixedVector<u64, U4> = FixedVector::try_from(vec).unwrap();
 
         // test the reference version
         assert_eq!((&fixed).into_iter().sum::<u64>(), 12);
@@ -457,7 +456,7 @@ mod test {
 
     #[test]
     fn ssz_encode() {
-        let vec: FixedVector<u16, U2> = vec![0; 2].into();
+        let vec: FixedVector<u16, U2> = vec![0; 2].try_into().unwrap();
         assert_eq!(vec.as_ssz_bytes(), vec![0, 0, 0, 0]);
         assert_eq!(<FixedVector<u16, U2> as Encode>::ssz_fixed_len(), 4);
     }
@@ -470,26 +469,26 @@ mod test {
 
     #[test]
     fn ssz_round_trip_u16_len_8() {
-        ssz_round_trip::<FixedVector<u16, U8>>(vec![42; 8].into());
-        ssz_round_trip::<FixedVector<u16, U8>>(vec![0; 8].into());
+        ssz_round_trip::<FixedVector<u16, U8>>(vec![42; 8].try_into().unwrap());
+        ssz_round_trip::<FixedVector<u16, U8>>(vec![0; 8].try_into().unwrap());
     }
 
     #[test]
     fn tree_hash_u8() {
-        let fixed: FixedVector<u8, U0> = FixedVector::from(vec![]);
+        let fixed: FixedVector<u8, U0> = FixedVector::try_from(vec![]).unwrap();
         assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 8], 0));
 
-        let fixed: FixedVector<u8, U1> = FixedVector::from(vec![0; 1]);
+        let fixed: FixedVector<u8, U1> = FixedVector::try_from(vec![0; 1]).unwrap();
         assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 8], 0));
 
-        let fixed: FixedVector<u8, U8> = FixedVector::from(vec![0; 8]);
+        let fixed: FixedVector<u8, U8> = FixedVector::try_from(vec![0; 8]).unwrap();
         assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 8], 0));
 
-        let fixed: FixedVector<u8, U16> = FixedVector::from(vec![42; 16]);
+        let fixed: FixedVector<u8, U16> = FixedVector::try_from(vec![42; 16]).unwrap();
         assert_eq!(fixed.tree_hash_root(), merkle_root(&[42; 16], 0));
 
         let source: Vec<u8> = (0..16).collect();
-        let fixed: FixedVector<u8, U16> = FixedVector::from(source.clone());
+        let fixed: FixedVector<u8, U16> = FixedVector::try_from(source.clone()).unwrap();
         assert_eq!(fixed.tree_hash_root(), merkle_root(&source, 0));
     }
 
@@ -513,28 +512,28 @@ mod test {
     fn tree_hash_composite() {
         let a = A { a: 0, b: 1 };
 
-        let fixed: FixedVector<A, U0> = FixedVector::from(vec![]);
+        let fixed: FixedVector<A, U0> = FixedVector::try_from(vec![]).unwrap();
         assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 32], 0));
 
-        let fixed: FixedVector<A, U1> = FixedVector::from(vec![a]);
+        let fixed: FixedVector<A, U1> = FixedVector::try_from(vec![a]).unwrap();
         assert_eq!(
             fixed.tree_hash_root(),
             merkle_root(a.tree_hash_root().as_slice(), 0)
         );
 
-        let fixed: FixedVector<A, U8> = FixedVector::from(vec![a; 8]);
+        let fixed: FixedVector<A, U8> = FixedVector::try_from(vec![a; 8]).unwrap();
         assert_eq!(
             fixed.tree_hash_root(),
             merkle_root(&repeat(a.tree_hash_root().as_slice(), 8), 0)
         );
 
-        let fixed: FixedVector<A, U13> = FixedVector::from(vec![a; 13]);
+        let fixed: FixedVector<A, U13> = FixedVector::try_from(vec![a; 13]).unwrap();
         assert_eq!(
             fixed.tree_hash_root(),
             merkle_root(&repeat(a.tree_hash_root().as_slice(), 13), 0)
         );
 
-        let fixed: FixedVector<A, U16> = FixedVector::from(vec![a; 16]);
+        let fixed: FixedVector<A, U16> = FixedVector::try_from(vec![a; 16]).unwrap();
         assert_eq!(
             fixed.tree_hash_root(),
             merkle_root(&repeat(a.tree_hash_root().as_slice(), 16), 0)
@@ -543,8 +542,8 @@ mod test {
 
     #[test]
     fn std_hash() {
-        let x: FixedVector<u32, U16> = FixedVector::from(vec![3; 16]);
-        let y: FixedVector<u32, U16> = FixedVector::from(vec![4; 16]);
+        let x: FixedVector<u32, U16> = FixedVector::try_from(vec![3; 16]).unwrap();
+        let y: FixedVector<u32, U16> = FixedVector::try_from(vec![4; 16]).unwrap();
         let mut hashset = HashSet::new();
 
         for value in [x.clone(), y.clone()] {

--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -110,7 +110,7 @@ impl<T, N: Unsigned> FixedVector<T, N> {
     }
 }
 
-impl<T: Default, N: Unsigned> TryFrom<Vec<T>> for FixedVector<T, N> {
+impl<T, N: Unsigned> TryFrom<Vec<T>> for FixedVector<T, N> {
     type Error = Error;
 
     fn try_from(vec: Vec<T>) -> Result<Self, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,14 +26,14 @@
 //! let mut example = Example {
 //!     bit_vector: Bitfield::new(),
 //!     bit_list: Bitfield::with_capacity(4).unwrap(),
-//!     variable_list: <_>::from(vec![0, 1]),
-//!     fixed_vector: <_>::from(vec![2, 3]),
+//!     variable_list: VariableList::try_from(vec![0, 1]).unwrap(),
+//!     fixed_vector: FixedVector::try_from(vec![2, 3, 4, 5, 6, 7, 8, 9]).unwrap(),
 //! };
 //!
 //! assert_eq!(example.bit_vector.len(), 8);
 //! assert_eq!(example.bit_list.len(), 4);
 //! assert_eq!(&example.variable_list[..], &[0, 1]);
-//! assert_eq!(&example.fixed_vector[..], &[2, 3, 0, 0, 0, 0, 0, 0]);
+//! assert_eq!(&example.fixed_vector[..], &[2, 3, 4, 5, 6, 7, 8, 9]);
 //!
 //! ```
 

--- a/src/serde_utils/quoted_u64_fixed_vec.rs
+++ b/src/serde_utils/quoted_u64_fixed_vec.rs
@@ -24,21 +24,21 @@ mod test {
     #[test]
     fn quoted_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": ["1", "2", "3", "4"] }"#).unwrap();
-        let expected: FixedVector<u64, U4> = FixedVector::from(vec![1, 2, 3, 4]);
+        let expected: FixedVector<u64, U4> = FixedVector::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
     #[test]
     fn unquoted_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": [1, 2, 3, 4] }"#).unwrap();
-        let expected: FixedVector<u64, U4> = FixedVector::from(vec![1, 2, 3, 4]);
+        let expected: FixedVector<u64, U4> = FixedVector::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
     #[test]
     fn mixed_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": ["1", 2, "3", "4"] }"#).unwrap();
-        let expected: FixedVector<u64, U4> = FixedVector::from(vec![1, 2, 3, 4]);
+        let expected: FixedVector<u64, U4> = FixedVector::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 

--- a/src/serde_utils/quoted_u64_var_list.rs
+++ b/src/serde_utils/quoted_u64_var_list.rs
@@ -1,6 +1,6 @@
 //! Formats `VariableList<u64,N>` and similar types using quotes.
 //!
-//! E.g., `VariableList::from(vec![0, 1, 2])` serializes as `["0", "1", "2"]`.
+//! E.g., `VariableList::try_from(vec![0, 1, 2])` serializes as `["0", "1", "2"]`.
 //!
 //! Quotes can be optional during decoding. If the length of the `Vec` is greater than `N`, deserialization fails.
 
@@ -76,21 +76,21 @@ mod test {
     #[test]
     fn quoted_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": ["1", "2", "3", "4"] }"#).unwrap();
-        let expected: VariableList<u64, U4> = VariableList::from(vec![1, 2, 3, 4]);
+        let expected: VariableList<u64, U4> = VariableList::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
     #[test]
     fn unquoted_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": [1, 2, 3, 4] }"#).unwrap();
-        let expected: VariableList<u64, U4> = VariableList::from(vec![1, 2, 3, 4]);
+        let expected: VariableList<u64, U4> = VariableList::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
     #[test]
     fn mixed_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": ["1", 2, "3", "4"] }"#).unwrap();
-        let expected: VariableList<u64, U4> = VariableList::from(vec![1, 2, 3, 4]);
+        let expected: VariableList<u64, U4> = VariableList::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
@@ -103,7 +103,7 @@ mod test {
     #[test]
     fn short_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": [1, 2] }"#).unwrap();
-        let expected: VariableList<u64, U4> = VariableList::from(vec![1, 2]);
+        let expected: VariableList<u64, U4> = VariableList::try_from(vec![1, 2]).unwrap();
         assert_eq!(obj.values, expected);
     }
 

--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -298,15 +298,17 @@ where
                 )));
             }
 
-            bytes
-                .chunks(T::ssz_fixed_len())
-                .try_fold(Vec::with_capacity(num_items), |mut vec, chunk| {
+            bytes.chunks(T::ssz_fixed_len()).try_fold(
+                Vec::with_capacity(num_items),
+                |mut vec, chunk| {
                     vec.push(T::from_ssz_bytes(chunk)?);
                     Ok(vec)
-                })
+                },
+            )
         } else {
             ssz::decode_list_of_variable_length_items(bytes, Some(max_len))
-        }?.try_into()
+        }?
+        .try_into()
         .map_err(|e| {
             ssz::DecodeError::BytesInvalid(format!("VariableList::try_from failed: {e:?}"))
         })

--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -438,6 +438,15 @@ mod test {
     fn u16_len_8() {
         round_trip::<VariableList<u16, U8>>(vec![42; 8].try_into().unwrap());
         round_trip::<VariableList<u16, U8>>(vec![0; 8].try_into().unwrap());
+        round_trip::<VariableList<u16, U8>>(vec![].try_into().unwrap());
+    }
+
+    #[test]
+    fn ssz_empty_list() {
+        let empty_list = VariableList::<u16, U8>::default();
+        let bytes = empty_list.as_ssz_bytes();
+        assert!(bytes.is_empty());
+        assert_eq!(VariableList::from_ssz_bytes(&[]).unwrap(), empty_list);
     }
 
     fn root_with_length(bytes: &[u8], len: usize) -> Hash256 {


### PR DESCRIPTION
This is a breaking API change, addressing the following issue:

- https://github.com/sigp/ssz_types/issues/12

This API footgun recently caused a bug in Lighthouse (https://github.com/sigp/lighthouse/pull/7921/files#r2292893620, https://github.com/sigp/lighthouse/pull/7927). It is past time for it to go.