### PR TITLE
Reduce noise in `Debug` impl of `VariableList` and `FixedVector`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ typenum = "1.12.0"
 smallvec = "1.8.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 itertools = "0.14.0"
+derivative = "2"
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/fixed_vector.rs
+++ b/src/fixed_vector.rs
@@ -1,5 +1,6 @@
 use crate::tree_hash::vec_tree_hash_root;
 use crate::Error;
+use derivative::Derivative;
 use serde::Deserialize;
 use serde_derive::Serialize;
 use std::marker::PhantomData;
@@ -44,10 +45,12 @@ pub use typenum;
 /// let err = FixedVector::<_, typenum::U5>::try_from(base.clone()).unwrap_err();
 /// assert_eq!(err, Error::OutOfBounds { i: 4, len: 5 });
 /// ```
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize, Derivative)]
+#[derivative(Debug = "transparent")]
 #[serde(transparent)]
 pub struct FixedVector<T, N> {
     vec: Vec<T>,
+    #[derivative(Debug = "ignore")]
     _phantom: PhantomData<N>,
 }
 

--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -1,5 +1,6 @@
 use crate::tree_hash::vec_tree_hash_root;
 use crate::Error;
+use derivative::Derivative;
 use serde::Deserialize;
 use serde_derive::Serialize;
 use std::marker::PhantomData;
@@ -47,10 +48,12 @@ pub use typenum;
 /// // Push a value to if it _does_ exceed the maximum.
 /// assert!(long.push(6).is_err());
 /// ```
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize, Derivative)]
+#[derivative(Debug = "transparent")]
 #[serde(transparent)]
 pub struct VariableList<T, N> {
     vec: Vec<T>,
+    #[derivative(Debug = "ignore")]
     _phantom: PhantomData<N>,
 }
 


### PR DESCRIPTION
The default debug output of these types contains a lot of unnecessary noise making it hard to read. This PR removes the type and `PhantomData` from debug output. 

## `VariableList`

### Before

Before:
```rust
VariableList { vec: [42, 42, 42, 42], _phantom: PhantomData<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>, typenum::bit::B0>> }
```

After:

```rust
[42, 42, 42, 42]
```

## `FixedVector`

### Before 

```rust
FixedVector { vec: [42, 42, 42, 42], _phantom: PhantomData<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>, typenum::bit::B0>> }
```

### After

```rust
[42, 42, 42, 42]
```