### PR TITLE
Add benchmarks for SSZ encoding/decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,14 @@ itertools = "0.14.0"
 derivative = "2"
 
 [dev-dependencies]
+criterion = "0.7.0"
 serde_json = "1.0.0"
 tree_hash_derive = "0.10.0"
+
+[[bench]]
+harness = false
+name = "encode_decode"
+
+# FIXME: remove before release
+[patch.crates-io]
+ethereum_ssz = { git = "https://github.com/sigp/ethereum_ssz", branch = "main" }

--- a/benches/encode_decode.rs
+++ b/benches/encode_decode.rs
@@ -1,0 +1,91 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use ssz::{Decode, Encode};
+use ssz_types::{FixedVector, VariableList};
+use std::hint::black_box;
+use std::time::Duration;
+use typenum::{U1048576, U131072};
+
+fn benchmark_fixed_vector(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fixed_vector");
+
+    let fixed_vector_u8 = FixedVector::<u8, U1048576>::new(vec![255u8; 1048576]).unwrap();
+    let fixed_vector_u64 = FixedVector::<u64, U131072>::new(vec![255u64; 131072]).unwrap();
+    let fixed_vector_bytes = fixed_vector_u8.as_ssz_bytes();
+
+    group.warm_up_time(Duration::from_secs(15));
+    group.measurement_time(Duration::from_secs(10));
+
+    group.bench_function("decode_u8_1m", |b| {
+        b.iter(|| {
+            let vector = FixedVector::<u8, U1048576>::from_ssz_bytes(&fixed_vector_bytes).unwrap();
+            black_box(vector);
+        });
+    });
+
+    group.bench_function("encode_u8_1m", |b| {
+        b.iter(|| {
+            let bytes = fixed_vector_u8.as_ssz_bytes();
+            black_box(bytes);
+        });
+    });
+
+    group.bench_function("decode_u64_128k", |b| {
+        b.iter(|| {
+            let vector = FixedVector::<u64, U131072>::from_ssz_bytes(&fixed_vector_bytes).unwrap();
+            black_box(vector);
+        });
+    });
+    group.bench_function("encode_u64_128k", |b| {
+        b.iter(|| {
+            let bytes = fixed_vector_u64.as_ssz_bytes();
+            black_box(bytes);
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_variable_list(c: &mut Criterion) {
+    let mut group = c.benchmark_group("variable_list");
+
+    let variable_list_u8 = VariableList::<u8, U1048576>::new(vec![255u8; 1048576]).unwrap();
+    let variable_list_u64 = VariableList::<u64, U131072>::new(vec![255u64; 131072]).unwrap();
+    let variable_list_bytes = variable_list_u8.as_ssz_bytes();
+
+    group.warm_up_time(Duration::from_secs(15));
+    group.measurement_time(Duration::from_secs(10));
+
+    group.bench_function("decode_u8_1m", |b| {
+        b.iter(|| {
+            let vector =
+                VariableList::<u8, U1048576>::from_ssz_bytes(&variable_list_bytes).unwrap();
+            black_box(vector);
+        });
+    });
+
+    group.bench_function("encode_u8_1m", |b| {
+        b.iter(|| {
+            let bytes = variable_list_u8.as_ssz_bytes();
+            black_box(bytes);
+        });
+    });
+
+    group.bench_function("decode_u64_128k", |b| {
+        b.iter(|| {
+            let vector =
+                VariableList::<u64, U131072>::from_ssz_bytes(&variable_list_bytes).unwrap();
+            black_box(vector);
+        });
+    });
+    group.bench_function("encode_u64_128k", |b| {
+        b.iter(|| {
+            let bytes = variable_list_u64.as_ssz_bytes();
+            black_box(bytes);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_fixed_vector, benchmark_variable_list);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 //! }
 //!
 //! let mut example = Example {
-//!     bit_vector: Bitfield::new(),
-//!     bit_list: Bitfield::with_capacity(4).unwrap(),
+//!     bit_vector: BitVector::new(),
+//!     bit_list: BitList::with_capacity(4).unwrap(),
 //!     variable_list: VariableList::try_from(vec![0, 1]).unwrap(),
 //!     fixed_vector: FixedVector::try_from(vec![2, 3, 4, 5, 6, 7, 8, 9]).unwrap(),
 //! };


### PR DESCRIPTION
These benchmarks can be used a baseline for measuring the performance improvements in:

- https://github.com/sigp/ssz_types/pull/55
