### PR TITLE
Add new method `repeat_full` to `VariableList`

### DIFF
--- a/src/variable_list.rs
+++ b/src/variable_list.rs
@@ -103,6 +103,17 @@ impl<T, N: Unsigned> VariableList<T, N> {
         }
     }
 
+    /// Creates a full list with the given element repeated.
+    pub fn repeat_full(elem: T) -> Self
+    where
+        T: Clone,
+    {
+        Self {
+            vec: vec![elem; N::to_usize()],
+            _phantom: PhantomData,
+        }
+    }
+
     /// Returns the number of values presently in `self`.
     pub fn len(&self) -> usize {
         self.vec.len()
@@ -381,6 +392,13 @@ mod test {
         let vec = vec![42; 4];
         let fixed: Result<VariableList<u64, U4>, _> = VariableList::new(vec);
         assert!(fixed.is_ok());
+    }
+
+    #[test]
+    fn repeat_full() {
+        let manual_list = VariableList::<u64, U5>::new(vec![42; 5]).unwrap();
+        let repeat_list = VariableList::<u64, U5>::repeat_full(42);
+        assert_eq!(manual_list, repeat_list);
     }
 
     #[test]


### PR DESCRIPTION
While working on https://github.com/sigp/lighthouse/pull/8032, there are a couple of situations where we initialize a `VariableList` into a full list of all 0's. Having to handle errors in this case when none can occur is a bit annoying so a dedicated function to do this helps to avoid an ugly `expect`. This was suggested by Michael here: https://github.com/sigp/lighthouse/pull/8032#discussion_r2366465330

This is the `VariableList` equivalent of the `from_elem` method on `FixedVector`. At a later time it might be worth considering renaming the `from_elem` method to `repeat` for consistency.