### PR TITLE
Use `div_ceil` in tree_hash impl

### DIFF
--- a/src/tree_hash.rs
+++ b/src/tree_hash.rs
@@ -8,9 +8,8 @@ where
 {
     match T::tree_hash_type() {
         TreeHashType::Basic => {
-            let mut hasher = MerkleHasher::with_leaves(
-                (max_leaves + T::tree_hash_packing_factor() - 1) / T::tree_hash_packing_factor(),
-            );
+            let mut hasher =
+                MerkleHasher::with_leaves(max_leaves.div_ceil(T::tree_hash_packing_factor()));
 
             for item in vec {
                 hasher


### PR DESCRIPTION
This fixes the warning that clippy was raising about manually re-implementing `div_ceil`. 