### PR TITLE
Release 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssz_types"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "List, vector and bitfield types for SSZ"
 license = "Apache-2.0"


### PR DESCRIPTION
New release for:

- #61
- #62 
- #63  

We also may as well add https://github.com/sigp/ssz_types/pull/56  since it's backwards compatible and something we should've had a while ago