### PR TITLE
Remove patch (not used by deps)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,3 @@ tree_hash_derive = "0.10.0"
 [[bench]]
 harness = false
 name = "encode_decode"
-
-# FIXME: remove before release
-[patch.crates-io]
-ethereum_ssz = { git = "https://github.com/sigp/ethereum_ssz", branch = "main" }


### PR DESCRIPTION
I accidentally left in my patch for ethereum_ssz, but this was unused by v0.12.x releases published to crates.io:

>  Cargo only looks at the patch settings in the Cargo.toml manifest at the root of the workspace. Patch settings defined in dependencies will be ignored.

https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section