### PR TITLE
Bump `tree_hash`

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Run tests
-      run: cargo test --release
+      run: cargo test --release --all-features
   coverage:
     name: cargo-tarpaulin
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-tree_hash = "0.10.0"
+tree_hash = { version = "0.11.0", default-features = false }
 ethereum_serde_utils = "0.8.0"
 ethereum_ssz = "0.9.0"
 serde = "1.0.0"
@@ -25,6 +25,10 @@ itertools = "0.14.0"
 criterion = "0.7.0"
 serde_json = "1.0.0"
 tree_hash_derive = "0.10.0"
+
+[features]
+default = ["ring"]
+ring = ["tree_hash/ring"]
 
 [[bench]]
 harness = false


### PR DESCRIPTION
Bump `tree_hash` to use the new version which makes `ring` optional 